### PR TITLE
Accept different file formats

### DIFF
--- a/webexteamsarchiver/webexteamsarchiver.py
+++ b/webexteamsarchiver/webexteamsarchiver.py
@@ -127,7 +127,7 @@ class WebexTeamsArchiver:
                 download_avatars: Download avatar images.
                 download_workers: Number of download workers for downloading files.
                 timestamp_format: Timestamp strftime format.
-                file_format: Define the compressed file format (tgz, zip)
+                file_format: Define the compressed file format (tar.gz, zip)
 
         Returns:
             Name of archive file.
@@ -166,11 +166,11 @@ class WebexTeamsArchiver:
         
         filename = ""
         if file_format == "gztar":
-            filename = f"{self.archive_folder_name}.tgz"
+            filename = f"{self.archive_folder_name}.tar.gz"
         elif file_format == "zip":
             filename = f"{self.archive_folder_name}.zip"
         else:
-            filename = f"{self.archive_folder_name}.tgz"
+            filename = f"{self.archive_folder_name}.tar.gz"
 
         return filename
 

--- a/webexteamsarchiver/webexteamsarchiver.py
+++ b/webexteamsarchiver/webexteamsarchiver.py
@@ -409,4 +409,4 @@ class WebexTeamsArchiver:
 
     def _compress_folder(self, file_format: str) -> None:
         """Compress `archive_folder_name` folder as `archive_folder_name`.tgz"""
-        make_archive(self.archive_folder_name, file_format, self.archive_folder_name)
+        shutil.make_archive(self.archive_folder_name, file_format, self.archive_folder_name)


### PR DESCRIPTION
For some operating systems (Windows), the tgz file format is not as common; zip file is better. I changed the code from using the tarfile module to use shutil.make_archive and included an extra option named file_format.

However, this is a breaking change as this code changes the extension from tgz to tar.gz which is the one that make_archive creates.

If we need to keep backward compatibility, it would be necessary to include a rename functionality.

I'm just creating the pull request to have the discussion around this change.